### PR TITLE
Support conditional execution of steps

### DIFF
--- a/src/github-action.json
+++ b/src/github-action.json
@@ -94,7 +94,7 @@
               },
               "if" : {
                 "$comment": "https://docs.github.com/en/actions/creating-actions/metadata-syntax-for-github-actions#runsstepsif",
-                "description": "https://github.blog/changelog/2021-11-09-github-actions-conditional-execution-of-steps-in-actions/",
+                "description": "The condition of the composite run step.",
                 "type": "string"
               },
               "uses": {

--- a/src/github-action.json
+++ b/src/github-action.json
@@ -92,6 +92,11 @@
                   }
                 ]
               },
+              "if" : {
+                "$comment": "https://docs.github.com/en/actions/creating-actions/metadata-syntax-for-github-actions#runsstepsif",
+                "description": "https://github.blog/changelog/2021-11-09-github-actions-conditional-execution-of-steps-in-actions/",
+                "type": "string"
+              },
               "uses": {
                 "$comment": "https://docs.github.com/en/actions/creating-actions/metadata-syntax-for-github-actions#runsstepsuses",
                 "description": "Selects an action to run as part of a step in your job.",


### PR DESCRIPTION
https://github.blog/changelog/2021-11-09-github-actions-conditional-execution-of-steps-in-actions/

> Actions written in YAML, also known as composite actions, now support if conditionals. This lets you prevent specific steps from executing unless a condition has been met. Like steps defined in workflows, you can use any supported context and expression to create a conditional.

🎊 