### PR TITLE
Fix #29 action-validator not working on ubuntu 20.04

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ jobs:
       matrix:
         include:
           - os: ubuntu-latest
-            target: x86_64-unknown-linux-gnu
+            target: x86_64-unknown-linux-musl
             asset_name: action-validator_linux_amd64
           - os: macos-latest
             target: x86_64-apple-darwin


### PR DESCRIPTION
It's the configuration used by Ripgrep

https://github.com/BurntSushi/ripgrep/blob/44fb9fce2c1ee1a86c450702ea3ca2952bf6c5a7/.github/workflows/release.yml#L76

