### PR TITLE
Fix action-validator to run for each file on pre-commit hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ Update your .pre-commit-config.yaml:
 ```
 repos:
 - repo: https://github.com/mpalmer/action-validator
-  rev: v0.4.0
+  rev: v0.4.1
   hooks:
     - id: action-validator
 ```

--- a/bin/run-action-validator
+++ b/bin/run-action-validator
@@ -10,9 +10,5 @@ fi
 for file in $@
 do
    echo "File: ${file}"
-   errors=$(action-validator $file 2>&1)
-   if [ ! -z "$errors" ]; then
-      echo "${errors}"
-      exit 1
-   fi
+   action-validator $file
 done

--- a/bin/run-action-validator
+++ b/bin/run-action-validator
@@ -7,4 +7,12 @@ if ! command -v action-validator &>/dev/null; then
 	exit 1
 fi
 
-action-validator "$@"
+for file in $@
+do
+   echo "File: ${file}"
+   errors=$(action-validator $file 2>&1)
+   if [ ! -z "$errors" ]; then
+      echo "${errors}"
+      exit 1
+   fi
+done

--- a/bin/run-action-validator
+++ b/bin/run-action-validator
@@ -7,8 +7,4 @@ if ! command -v action-validator &>/dev/null; then
 	exit 1
 fi
 
-for file in $@
-do
-   echo "File: ${file}"
-   action-validator $file
-done
+action-validator "$@"


### PR DESCRIPTION
## Changes
- `bin/run-action-validator` is now an executable file.
- `action-validator` only takes a single file as input. This will fix pre-commit runs when multiple files are passed to entry script.

As an alternative, I'd be happy to raise a PR which let's `action-validator` accept multiple files as inputs. However, this would come with some questions:
1. What should happen if 1 file is valid but another is not? Or if 1 file is valid but multiple are not?
2. What should happen if 1 file fails? Does the CLI output to stderr on the first failure, or accumulate failures and report all of them?