### PR TITLE
Use language: rust in .pre-commit-hooks

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,6 +1,6 @@
--   id: action-validator
-    name: 'action validator'
-    entry: bin/run-action-validator
-    files: '.github/workflows/.*\.ya?ml'
-    language: 'script'
-    description: "Validate GitHub Actions workflows"
+- id: action-validator
+  name: Validate GitHub Actions workflows
+  description: "Validate GitHub Actions workflows"
+  entry: action-validator
+  language: rust
+  files: '.github/workflows/.*\.ya?ml'


### PR DESCRIPTION
Closes #74.

I've tested this on my local system with:
- Ubuntu 24.10.
- pre-commit 0.8.0.
- No manual install of Rust or action-validator. This means that pre-commit is bootstrapping rust and the repo.

Perhaps @andrewring or @glatterf42 (from the linked issue) could also experiment, or @mpalmer could indicate other checks/tests/additions in order for this to be ready to merge.