### PR TITLE
ci: fix wasm-bindgen warning on nightly

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,3 +47,6 @@ wasm-bindgen-test = "0.3.13"
 [profile.release]
 # Tell `rustc` to optimize for small code size.
 opt-level = "s"
+
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(wasm_bindgen_unstable_test_coverage)'] }


### PR DESCRIPTION
Fixes https://github.com/mpalmer/action-validator/issues/78

# Explanation

When CI runs on nightly rust, with wasm-bindgen >= 0.2.93, the `wasm_bindgen_unstable_test_coverage` is reported as an unknown condition. This appears to be a [bug in wasm-bindgen](https://github.com/rustwasm/wasm-bindgen/issues/4283), but it should not affect action-validator. For now, we can [statically declare the wasm_bindgen_unstable_test_coverage cfg as expected](https://blog.rust-lang.org/2024/05/06/check-cfg.html#expecting-custom-cfgs) by adding the following to our `Cargo.toml`:

```toml
[lints.rust]
unexpected_cfgs = { level = "warn", check-cfg = ['cfg(wasm_bindgen_unstable_test_coverage)'] }
```