### PR TITLE
Revert "ci: fix wasm-bindgen warning on nightly"

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,9 +1,6 @@
 # Ignore everything
 *
 
-# But not .mjs files
-!*.mjs
-!*.js
-
-# In all subdirectories
-!*/
+# But not JavaScript files in the packages directory
+!packages/**/*.mjs
+!packages/**/*.js

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,6 +47,3 @@ wasm-bindgen-test = "0.3.13"
 [profile.release]
 # Tell `rustc` to optimize for small code size.
 opt-level = "s"
-
-[lints.rust]
-unexpected_cfgs = { level = "warn", check-cfg = ['cfg(wasm_bindgen_unstable_test_coverage)'] }


### PR DESCRIPTION
This reverts commit a104c100fa2f761108f6f5e9560c359a875d2bbe (#80) which is no longer needed as per https://github.com/mpalmer/action-validator/issues/78#issuecomment-2506546148.

EDIT: And also fix the prettier issue