### PR TITLE
Update docs to point to working version for pre-commit config

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,10 +107,10 @@ This may seem a little redundant (after all, an action has to be valid in order 
 
 Update your .pre-commit-config.yaml:
 
-```
+```yaml
 repos:
 - repo: https://github.com/mpalmer/action-validator
-  rev: v0.5.1
+  rev: v0.7.1
   hooks:
     - id: action-validator
 ```


### PR DESCRIPTION
Previously, the README pointed to v0.5.1, which didn't work with pre-commit.  This PR updates the README to point to the latest version, which works nicely with pre-commit (and also syntax highlights the associated yaml).