### PR TITLE
feat: `--auto` workflow/action discovery

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -8,7 +8,7 @@ inputs:
   patterns:
     description: 'Newline-separated list of git ls-files patterns'
     required: false
-    default: |
+    default: | # If you update this list, also update src/lib.rs
       :(glob).github/**/action.yml
       :(glob).github/**/action.yaml
       .github/workflows/*.yml

--- a/src/config.rs
+++ b/src/config.rs
@@ -19,6 +19,10 @@ pub struct CliConfig {
     )]
     pub rootdir: Option<PathBuf>,
 
+    /// Automatically find and validate GitHub Actions files via git
+    #[arg(long)]
+    pub auto: bool,
+
     /// Input file
     #[arg(name = "path_to_action_yaml")]
     pub src: Vec<PathBuf>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -89,6 +89,8 @@ mod js {
 }
 
 pub mod cli {
+    use std::path::PathBuf;
+
     use crate::{
         config::{ActionType, RunConfig},
         system, CliConfig,
@@ -102,7 +104,41 @@ pub mod cli {
     pub fn run(config: &CliConfig) -> RunResult {
         let mut success = true;
 
-        for path in &config.src {
+        let mut paths: Vec<PathBuf> = Vec::new();
+
+        if config.auto {
+            const AUTO_PATHSPECS: &[&str] = &[
+                // If you update this list, also update action.yml
+                ":(glob).github/**/action.yml",
+                ":(glob).github/**/action.yaml",
+                ".github/workflows/*.yml",
+                ".github/workflows/*.yaml",
+            ];
+
+            match system::git::ls_files_with_pathspecs(AUTO_PATHSPECS) {
+                Ok(files) => {
+                    paths.extend(files.into_iter().map(PathBuf::from));
+                }
+                Err(err) => {
+                    system::console::error(&format!("Failed to discover files: {err}"));
+                    return RunResult::Failure;
+                }
+            }
+        }
+
+        paths.extend_from_slice(&config.src);
+
+        if paths.is_empty() {
+            if config.auto {
+                return RunResult::Success;
+            }
+            system::console::error(
+                "No input files. Provide file paths and/or use --auto to discover them.",
+            );
+            return RunResult::Failure;
+        }
+
+        for path in &paths {
             let file_name = match path.file_name() {
                 Some(file_name) => file_name.to_str(),
                 None => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -204,7 +204,17 @@ fn run(config: &RunConfig) -> ValidationState {
         Ok(doc) => match config.action_type {
             ActionType::Action => {
                 if config.verbose {
-                    system::console::log(&format!("Treating {file_name} as an Action definition"));
+                    let display_name = config
+                        .file_path
+                        .and_then(|p| {
+                            let path = std::path::Path::new(p);
+                            let parent = path.parent()?.file_name()?.to_str()?;
+                            Some(format!("{parent}/{file_name}"))
+                        })
+                        .unwrap_or_else(|| file_name.to_string());
+                    system::console::log(&format!(
+                        "Treating {display_name} as an Action definition"
+                    ));
                 }
                 validate_as_action(&doc)
             }

--- a/src/system/git.rs
+++ b/src/system/git.rs
@@ -1,7 +1,14 @@
 use std::process::Command;
 
 pub fn ls_files() -> Result<Vec<String>, std::io::Error> {
-    let output = Command::new("git").args(["ls-files", "-z"]).output()?;
+    ls_files_with_pathspecs(&[])
+}
+
+pub fn ls_files_with_pathspecs(pathspecs: &[&str]) -> Result<Vec<String>, std::io::Error> {
+    let output = Command::new("git")
+        .args(["ls-files", "-z"])
+        .args(pathspecs)
+        .output()?;
 
     if !output.status.success() {
         return Err(std::io::Error::other(format!(


### PR DESCRIPTION
1) adds `--auto` flag that uses the same patterns as `action.yml`:

https://github.com/mpalmer/action-validator/blob/4249884ff1561279ceeab1f6a624eb0be52fd6ec/action.yml#L8-L15

2) enhances `--verbose` output:
  - before: `Treating action.yml as an Action definition`
  - after: `Treating foo/action.yml as an Action definition`
  - Relevant since the default `--auto` patterns are fairly cautious (only discovering files under `.github/`), so that people can fairly easily notice even upon success if all expected files are covered or not

`--auto` can be used together with providing a list of files. Not mutually exclusive.

* Resolves https://github.com/mpalmer/action-validator/issues/108